### PR TITLE
Fixed forbidden url bug when downloading 2016 household projections

### DIFF
--- a/ukpopulation/snhpdata.py
+++ b/ukpopulation/snhpdata.py
@@ -176,7 +176,8 @@ class SNHPData:
         if os.path.isfile(scotland_processed):
             snhp_s = pd.read_csv(scotland_processed)
         else:
-            response = requests.get(scotland_src)
+            headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:105.0) Gecko/20100101 Firefox/105.0'}
+            response = requests.get(scotland_src, headers=headers)
             with open(scotland_raw, 'wb') as fd:
                 for chunk in response.iter_content(chunk_size=1024):
                     fd.write(chunk)


### PR DESCRIPTION
When attempting to download the zip file for 2016 household projections from nrscotland ([link](https://www.nrscotland.gov.uk/files//statistics/household-projections/16/2016-house-proj-detailed-coun-princ.zip)), the code previously downloaded a 403 error page and cached that in place of the `2016-house-proj-detailed-counc-princ.zip` file. This caused downstream errors in the microsimulation package as it was expecting a zip file, but encountering a html file in disguise.

I defined a user-agent based (below) on linux and firefox to pass to the requests.get function which seems to fix the problem.

```
headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:105.0) Gecko/20100101 Firefox/105.0'}
response = requests.get(scotland_src, headers=headers)
```